### PR TITLE
Release v0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,13 @@ jobs:
           echo "cargo dist plan ran successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
-          path: dist-manifest.json
+          # Added: `dpedal_flash/` as its written to a different path now
+          path: dpedal_flash/dist-manifest.json
 
   # Build and packages all the platform-specific things
   upload-local-artifacts:
@@ -139,9 +141,10 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: artifacts
+          # Added: `dpedal_flash/` as its written to a different path now
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
-            ${{ env.BUILD_MANIFEST_NAME }}
+            dpedal_flash/${{ env.BUILD_MANIFEST_NAME }}
 
   should-publish:
     needs:

--- a/dpedal_flash/Cargo.lock
+++ b/dpedal_flash/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "dpedalflash"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "dfu-libusb",

--- a/dpedal_flash/Cargo.toml
+++ b/dpedal_flash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dpedalflash"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/rukai/DPedal"
 


### PR DESCRIPTION
Seems like I had previously accidentally bumped dpedal_firmware instead of dpedal_flash when making 0.1.1, resulting in me attempting to make a second 0.1.1 release.
Additionally I attempted to manually fix some issues with the generated GA yaml, we'll see if this works or not.
To fix these I am immediately superceding https://github.com/rukai/DPedal/pull/1 with a v0.1.2 release.