### PR TITLE
Port to usbd_human_interface_device

### DIFF
--- a/dpedal_firmware/Cargo.lock
+++ b/dpedal_firmware/Cargo.lock
@@ -60,6 +60,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bxcan"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +127,7 @@ checksum = "f0f6f3e36f203cfedbc78b357fb28730aa2c6dc1ab060ee5c2405e843988d3c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -127,7 +139,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
  "cortex-m-rtic-macros",
- "heapless",
+ "heapless 0.7.16",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -143,7 +155,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rtic-syntax",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -160,12 +172,14 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",
+ "frunk",
  "keyberon",
  "nb 1.1.0",
  "once_cell",
  "panic-halt",
  "stm32f0xx-hal",
  "usb-device",
+ "usbd-human-interface-device",
 ]
 
 [[package]]
@@ -185,10 +199,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "frunk"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a351b59e12f97b4176ee78497dff72e4276fb1ceb13e19056aca7fa0206287"
+dependencies = [
+ "frunk_core",
+ "frunk_derives",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2469fab0bd07e64ccf0ad57a1438f63160c69b2e57f04a439653d68eb558d6"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fa992f1656e1707946bbba340ad244f0814009ef8c0118eb7b658395f19a2e"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b54add839292b743aeda6ebedbd8b11e93404f902c56223e51b9ec18a13d2c"
+dependencies = [
+ "frunk_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "fugit"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
+dependencies = [
+ "gcd",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
@@ -206,9 +289,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill 0.1.11",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version 0.4.0",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -230,7 +323,7 @@ dependencies = [
  "arraydeque",
  "either",
  "embedded-hal",
- "heapless",
+ "heapless 0.7.16",
  "keyberon-macros",
  "usb-device",
 ]
@@ -271,6 +364,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "num_enum"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +391,33 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 dependencies = [
  "atomic-polyfill 1.0.3",
  "critical-section",
+]
+
+[[package]]
+name = "option-block"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f2c5d345596a14d7c8b032a68f437955f0059f2eb9a5972371c84f7eef3227"
+
+[[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec",
+ "packed_struct_codegen",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -295,7 +435,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -329,6 +469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rtic-core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +495,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -464,6 +610,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +637,21 @@ name = "usb-device"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
+name = "usbd-human-interface-device"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635a89fd1ca1d3ca406cf04a98f701f507b2b5ba20b3b7ef701b37b626156235"
+dependencies = [
+ "frunk",
+ "fugit",
+ "heapless 0.8.0",
+ "num_enum",
+ "option-block",
+ "packed_struct",
+ "usb-device",
+]
 
 [[package]]
 name = "vcell"
@@ -500,4 +678,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]

--- a/dpedal_firmware/Cargo.toml
+++ b/dpedal_firmware/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/rukai/DPedal"
 
+# TODO: use bindeps to remove "cargo calling cargo" hacks https://rust-lang.github.io/rfcs/3176-cargo-multi-dep-artifacts.html
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,9 +19,14 @@ embedded-hal = "0.2"
 usb-device = "0.2.0"
 nb = "1.0.0"
 once_cell = { version = "1.17.0", default-features = false, features = ["critical-section"] }
+usbd-human-interface-device = "0.4.4"
+frunk = { version = "0.4.2", default-features = false }
 
 [profile.release]
 lto = true
 incremental = false
 opt-level = "z"
 debug = true
+
+[profile.dev]
+opt-level = "z"

--- a/dpedal_firmware/src/main.rs
+++ b/dpedal_firmware/src/main.rs
@@ -1,8 +1,6 @@
 #![no_main]
 #![no_std]
 
-use keyberon::action::Action;
-use once_cell::sync::Lazy;
 // set the panic handler
 use panic_halt as _;
 
@@ -10,20 +8,29 @@ use hal::gpio::{Input, Pin, PullUp};
 use hal::prelude::*;
 use hal::usb;
 use hal::{stm32, timers};
+use keyberon::action::Action;
 use keyberon::debounce::Debouncer;
-use keyberon::key_code::KbHidReport;
+use keyberon::key_code::KeyCode;
+use keyberon::layout::CustomEvent;
 use keyberon::layout::{Event, Layers, Layout};
 use keyberon::matrix::DirectPinMatrix;
+use once_cell::sync::Lazy;
 use rtic::app;
 use stm32f0xx_hal as hal;
 use usb_device::bus::UsbBusAllocator;
-use usb_device::class::UsbClass as _;
-use usb_device::device::UsbDeviceState;
+use usbd_human_interface_device::device::keyboard::{NKROBootKeyboard, NKROBootKeyboardConfig};
+use usbd_human_interface_device::device::mouse::{WheelMouse, WheelMouseConfig, WheelMouseReport};
+use usbd_human_interface_device::page::Keyboard;
+use usbd_human_interface_device::prelude::*;
 
-type UsbClass = keyberon::Class<'static, usb::UsbBusType, ()>;
 type UsbDevice = usb_device::device::UsbDevice<'static, usb::UsbBusType>;
+type MultiDevice = frunk::HList!(
+    WheelMouse<'static, hal::usb::UsbBusType>,
+    NKROBootKeyboard<'static, hal::usb::UsbBusType>,
+);
 
-static LAYERS: Lazy<Layers<8, 1, 1>> = Lazy::new(|| unsafe {
+// TODO: We'll probably need to vendor the keyberon bits we need so we can make layers runtime configurable
+static LAYERS: Lazy<Layers<8, 1, 1, MouseEvent>> = Lazy::new(|| unsafe {
     [[[
         action_from_mem(0), // up
         action_from_mem(1), // down
@@ -36,10 +43,27 @@ static LAYERS: Lazy<Layers<8, 1, 1>> = Lazy::new(|| unsafe {
     ]]]
 });
 
-unsafe fn action_from_mem(offset: usize) -> Action {
+#[derive(Clone, Copy)]
+enum MouseEvent {
+    ScrollUp,
+    ScrollDown,
+}
+
+#[derive(Clone, Copy, Default)]
+struct MouseState {
+    ticks_since_last_change: u32,
+    event: Option<MouseEvent>,
+}
+
+unsafe fn action_from_mem(offset: usize) -> Action<MouseEvent> {
     let config = (0x0800_8000 + offset) as *mut u8;
     let config_byte1 = unsafe { core::ptr::read_volatile(config) };
-    Action::KeyCode(unsafe { core::mem::transmute(config_byte1) })
+    let keycode: KeyCode = unsafe { core::mem::transmute(config_byte1) };
+    match keycode {
+        KeyCode::MediaScrollUp => Action::Custom(MouseEvent::ScrollUp),
+        KeyCode::MediaScrollDown => Action::Custom(MouseEvent::ScrollDown),
+        _ => Action::KeyCode(keycode),
+    }
 }
 
 #[app(device = crate::hal::pac, peripherals = true, dispatchers = [CEC_CAN])]
@@ -48,10 +72,10 @@ mod app {
 
     #[shared]
     struct Shared {
-        usb_dev: UsbDevice,
-        usb_class: UsbClass,
+        multi_device: UsbHidClass<'static, hal::usb::UsbBusType, MultiDevice>,
+        usb_device: UsbDevice,
         #[lock_free]
-        layout: Layout<8, 1, 1>,
+        layout: Layout<8, 1, 1, MouseEvent>,
     }
 
     #[local]
@@ -59,6 +83,7 @@ mod app {
         matrix: DirectPinMatrix<Pin<Input<PullUp>>, 8, 1>,
         debouncer: Debouncer<[[bool; 8]; 1]>,
         timer: timers::Timer<stm32::TIM3>,
+        mouse_state: MouseState,
     }
 
     #[init(local = [bus: Option<UsbBusAllocator<usb::UsbBusType>> = None])]
@@ -84,9 +109,20 @@ mod app {
         };
         *c.local.bus = Some(usb::UsbBusType::new(usb));
         let usb_bus = c.local.bus.as_ref().unwrap();
+        let multi_device = UsbHidClassBuilder::new()
+            .add_device(NKROBootKeyboardConfig::default())
+            .add_device(WheelMouseConfig::default())
+            .build(usb_bus);
 
-        let usb_class = keyberon::new_class(usb_bus, ());
-        let usb_dev = keyberon::new_device(usb_bus);
+        // https://pid.codes
+        let usb_device = usb_device::device::UsbDeviceBuilder::new(
+            usb_bus,
+            usb_device::device::UsbVidPid(0x1209, 0x0001),
+        )
+        .manufacturer("rukai")
+        .product("dpedal")
+        .serial_number("TEST")
+        .build();
 
         let mut timer = timers::Timer::tim3(c.device.TIM3, 1.khz(), &mut rcc);
         timer.listen(timers::Event::TimeOut);
@@ -107,26 +143,32 @@ mod app {
 
         (
             Shared {
-                usb_dev,
-                usb_class,
+                multi_device,
+                usb_device,
                 layout: Layout::new(&LAYERS),
             },
             Local {
                 timer,
                 debouncer: Debouncer::new([[false; 8]; 1], [[false; 8]; 1], 5),
                 matrix,
+                mouse_state: MouseState::default(),
             },
             init::Monotonics(),
         )
     }
 
-    #[task(binds = USB, priority = 3, shared = [usb_dev, usb_class])]
+    #[task(binds = USB, priority = 3, shared = [multi_device, usb_device])]
     fn usb_rx(c: usb_rx::Context) {
-        (c.shared.usb_dev, c.shared.usb_class).lock(|usb_dev, usb_class| {
-            if usb_dev.poll(&mut [usb_class]) {
-                usb_class.poll();
+        (c.shared.multi_device, c.shared.usb_device).lock(|multi_device, usb_device| {
+            if usb_device.poll(&mut [multi_device]) {
+                let interface = multi_device.device::<NKROBootKeyboard<'_, _>, _>();
+                match interface.read_report() {
+                    Err(usb_device::UsbError::WouldBlock) => {}
+                    Err(e) => core::panic!("Failed to read keyboard report: {:?}", e),
+                    Ok(_) => {}
+                }
             }
-        });
+        })
     }
 
     #[task(priority = 2, capacity = 8, shared = [layout])]
@@ -134,22 +176,65 @@ mod app {
         c.shared.layout.event(event)
     }
 
-    #[task(priority = 2, shared = [usb_dev, usb_class, layout])]
+    #[task(priority = 2, shared = [layout, multi_device], local = [mouse_state])]
     fn tick_keyberon(mut c: tick_keyberon::Context) {
-        c.shared.layout.tick();
-        if c.shared.usb_dev.lock(|d| d.state()) != UsbDeviceState::Configured {
-            return;
+        match c.shared.layout.tick() {
+            CustomEvent::Press(e) => {
+                c.local.mouse_state.event = Some(*e);
+                c.local.mouse_state.ticks_since_last_change = 0;
+            }
+            CustomEvent::Release(_) => {
+                c.local.mouse_state.event = None;
+                c.local.mouse_state.ticks_since_last_change = 0;
+            }
+            CustomEvent::NoEvent => {}
         }
-        let report: KbHidReport = c.shared.layout.keycodes().collect();
 
-        if !c
-            .shared
-            .usb_class
-            .lock(|k| k.device_mut().set_keyboard_report(report.clone()))
-        {
-            return;
+        let t = c.local.mouse_state.ticks_since_last_change;
+        let mut mouse_report = WheelMouseReport::default();
+        match c.local.mouse_state.event {
+            Some(MouseEvent::ScrollDown) => {
+                mouse_report.vertical_wheel = -if t % 100 == 0 { 1 } else { 0 }
+            }
+            Some(MouseEvent::ScrollUp) => {
+                mouse_report.vertical_wheel = if t % 100 == 0 { 1 } else { 0 }
+            }
+            None => {}
         }
-        while let Ok(0) = c.shared.usb_class.lock(|k| k.write(report.as_bytes())) {}
+
+        // Run this after generating mouse_report to ensure the first tick is at 0
+        c.local.mouse_state.ticks_since_last_change += 1;
+
+        let keyboard_report = c.shared.layout.keycodes().map(|x| Keyboard::from(x as u8));
+
+        c.shared.multi_device.lock(|multi_device| {
+            match multi_device
+                .device::<NKROBootKeyboard<'_, _>, _>()
+                .write_report(keyboard_report)
+            {
+                Err(UsbHidError::WouldBlock) => {}
+                Err(UsbHidError::Duplicate) => {}
+                Ok(_) => {}
+                Err(e) => core::panic!("Failed to write keyboard report: {:?}", e),
+            }
+
+            // Sending empty mouse reports achieves nothing and appears to cause issues by sending too many reports
+            // So we check for empty reports and skip
+            if mouse_report != WheelMouseReport::default() {
+                let mouse = multi_device.device::<WheelMouse<'_, _>, _>();
+                match mouse.write_report(&mouse_report) {
+                    Err(UsbHidError::WouldBlock) => {}
+                    Ok(_) => {}
+                    Err(e) => core::panic!("Failed to write mouse report: {:?}", e),
+                };
+            }
+        });
+
+        c.shared.multi_device.lock(|k| match k.tick() {
+            Err(UsbHidError::WouldBlock) => {}
+            Ok(_) => {}
+            Err(e) => core::panic!("Failed to process keyboard tick: {:?}", e),
+        });
     }
 
     #[task(
@@ -163,6 +248,13 @@ mod app {
         for event in c.local.debouncer.events(c.local.matrix.get().unwrap()) {
             handle_event::spawn(event).unwrap();
         }
+
         tick_keyberon::spawn().unwrap();
     }
 }
+
+// Implemented by reference to these examples:
+// https://github.com/dlkj/usbd-human-interface-device/blob/main/examples/src/bin/keyboard_rtic.rs
+// https://github.com/dlkj/usbd-human-interface-device/blob/main/examples/src/bin/multi_device.rs
+// https://github.com/dlkj/usbd-human-interface-device/blob/main/examples/src/bin/keyboard_nkro.rs
+// https://github.com/dlkj/usbd-human-interface-device/blob/main/examples/src/bin/mouse_wheel.rs


### PR DESCRIPTION
usbd_human_interface_device provides support for mouse devices which keyberon does not.
In order to support mouse inputs I have ported all our usb interactions from keyberon to usbd_human_interface_device.
keyberon is still used for things like keymapping, but I want to fully remove it eventually as it has poor support for runtime keymapping